### PR TITLE
Differentiating right and left click behavior

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -110,17 +110,17 @@ window.onkeypress = function(e){
             break;
     }
 };
-cnv.onmousedown = function({ x, y }){
+cnv.onmousedown = function({button, x, y }){
     contextMenu();
 
-    if(mode === 'move'){
+    if(mode === 'move' && button !== 2){
         const states = fa.findNearestStates(x, y);
         if(states.length){
             activeState = states[0].name;
         }
     }
 
-    if(mode === 'design'){
+    if(mode === 'design' && button !== 2){
         const states = fa.findNearestStates(x, y);
         if(states.length) {
             activeState = states[0].name;


### PR DESCRIPTION
I disabled path creation on states' right click in 'design' mode and also disabled state movement of holding down right click in 'move' mode.
In my opinion right click should have differentiated from left click because in 'design' mode, paths should be created on states' left click and in 'move' mode, only states' left click can move the states

I hope you accept my pull request 🥳